### PR TITLE
Fix README grammar, typos, and outdated links

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -58,7 +58,7 @@ Support for these scripts is community based via GitHub issues. MPS team does no
 ## Links
 
 - [PlayFab Multiplayer Services](https://playfab.com/multiplayer)
-- [PlayFab Multiplayer Servers Documentation](https://docs.microsoft.com/en-us/gaming/playfab/features/multiplayer/servers/overview)
+- [PlayFab Multiplayer Servers Documentation](https://learn.microsoft.com/en-us/gaming/playfab/features/multiplayer/servers/overview)
 - [PlayFab Game Server SDK (GSDK)](https://github.com/PlayFab/gsdk)
 - [PlayFab GSDK samples](https://github.com/PlayFab/MpsSamples)
 - [Local Multiplayer Agent](https://github.com/PlayFab/MpsAgent)

--- a/linux_logs_fluentbit_kusto/README.md
+++ b/linux_logs_fluentbit_kusto/README.md
@@ -16,13 +16,13 @@ You should refer to the documentation for [Fluent Bit Azure Data Explorer plugin
 
 - Create a Kusto cluster and database to store the data ([click here for a free cluster](https://dataexplorer.azure.com/freecluster))
 - Create an Azure Registered Application so that fluentbit can authenticate to the cluster
-  - [Register an application](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#register-an-application)
-  - [Add a client secret](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#add-a-client-secret)
-  - [Authorize the app in the database](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/management/access-control/principals-and-identity-providers#azure-ad-tenants)
-    - During our tests, it wasn't clear if adding the service Principal in the table "users" was enough, or if it was also necessary to add it in the table "ingestors" or "admins"
+  - [Register an application](https://learn.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#register-an-application)
+  - [Add a client secret](https://learn.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#add-a-client-secret)
+  - [Authorize the app in the database](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/access-control/principals-and-identity-providers#azure-ad-tenants)
+    - During our tests, it was unclear whether adding the service principal to the "users" table was sufficient, or if it also needed to be added to "ingestors" or "admins"
 
 ```kql
-// Azure AD App on your tenant tenant - by tenant ID
+// Azure AD App on your tenant - by tenant ID
 .add database MyDatabase admins ('aadapp=<servicePrincipalApplicationID>;<tenantID>') 'Test app for fluentbit'
 ```
 

--- a/linux_logs_metrics_telegraf_kusto/README.md
+++ b/linux_logs_metrics_telegraf_kusto/README.md
@@ -25,15 +25,15 @@ You should refer to the documentation for the input plugins you can use, specifi
 
 Documentation for the [telegraf Azure Data Explorer output plugin is here](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/azure_data_explorer). To use this plugin, you need to:
 
-- Create a Azure Data Explorer (Kusto) cluster and database to store the data ([check here for a free cluster](https://dataexplorer.azure.com/freecluster))
+- Create an Azure Data Explorer (Kusto) cluster and database to store the data ([check here for a free cluster](https://dataexplorer.azure.com/freecluster))
 - Create an Azure Registered Application so that telegraf can authenticate to the cluster
-  - [Register an application](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#register-an-application)
-  - [Add a client secret](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#add-a-client-secret)
-  - [Authorize the app in the database](https://docs.microsoft.com/en-us/azure/data-explorer/kusto/management/access-control/principals-and-identity-providers#azure-ad-tenants)
+  - [Register an application](https://learn.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#register-an-application)
+  - [Add a client secret](https://learn.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#add-a-client-secret)
+  - [Authorize the app in the database](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/access-control/principals-and-identity-providers#azure-ad-tenants)
     - If you want telegraf to dynamically create tables, you should add this to the group "admins". If you want to create the tables manually, you should add this to the group "users" or "ingestors".
 
 ```kql
-// Azure AD App on your tenant tenant - by tenant ID
+// Azure AD App on your tenant - by tenant ID
 .add database MyDatabase admins ('aadapp=<servicePrincipalApplicationID>;<tenantID>') 'Test app for telegraf'
 ```
 

--- a/linux_metrics_telegraf_azuremonitor/README.md
+++ b/linux_metrics_telegraf_azuremonitor/README.md
@@ -10,7 +10,7 @@ You can see documentation about [Azure Monitor output telegraf plugin here](http
 
 ## What it does
 
-This script uses [telegraf](https://www.influxdata.com/time-series-platform/telegraf/) agent to capture and send VM metrics (CPU/Disk/Mem/Network) to Azure Monitor. The telegraf agent publishes [custom metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-custom-overview) using the Azure Monitor REST API (preview). Custom metrics are available in these [regions](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-custom-overview#supported-regions). This script is applicable if you are running Linux MPS Builds using containers or processes for your game servers.
+This script uses [telegraf](https://www.influxdata.com/time-series-platform/telegraf/) agent to capture and send VM metrics (CPU/Disk/Mem/Network) to Azure Monitor. The telegraf agent publishes [custom metrics](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/metrics-custom-overview) using the Azure Monitor REST API (preview). Custom metrics are available in these [regions](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/metrics-custom-overview#supported-regions). This script is applicable if you are running Linux MPS Builds using containers or processes for your game servers.
 
 ## Usage
 
@@ -18,7 +18,7 @@ You should download telegraf from the [GitHub releases](https://github.com/influ
 
 You should create an Azure resource where the Azure Monitor metrics will be published to. For our sample, we created a VMSS (Virtual Machine Scaleset resource) with 0 Virtual Machines (so there is no compute charge). Once you do that, you should copy the resource ID (and, optionally, the region) and add it to the telegraf.conf file.
 
-We need telegraf to be able to authenticate to Azure Monitor on your subscription so it can post the metrics. Out of the [supported methods](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/azure_monitor/README.md#authentication), we'll use the service principal authentication. You can use the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/) to create a service principal with the "Monitoring Metrics Publisher" role for the subscription that metrics will be published against - the subscription that contains the VMSS resource you created. The subscription ID can be retrieved using `az account list` or from the Azure portal.
+We need telegraf to be able to authenticate to Azure Monitor on your subscription so it can post the metrics. Out of the [supported methods](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/azure_monitor/README.md#authentication), we'll use the service principal authentication. You can use the [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/) to create a service principal with the "Monitoring Metrics Publisher" role for the subscription that metrics will be published against - the subscription that contains the VMSS resource you created. The subscription ID can be retrieved using `az account list` or from the Azure portal.
 
 ```bash
 az ad sp create-for-rbac --role="Monitoring Metrics Publisher" --scopes="/subscriptions/<replace-with-subscription-id>"

--- a/windows_metrics_telegraf_applicationinsights/README.md
+++ b/windows_metrics_telegraf_applicationinsights/README.md
@@ -10,7 +10,7 @@ You can see documentation about Application Insights output telegraf plugin [her
 
 ## What it does
 
-This script uses [telegraf](https://www.influxdata.com/time-series-platform/telegraf/) agent to send VM metrics to Application Insights. The telegraf agent publishes [custom metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-custom-overview) using the Azure Monitor REST API. Custom metrics are available in these [regions](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-custom-overview#supported-regions).
+This script uses [telegraf](https://www.influxdata.com/time-series-platform/telegraf/) agent to send VM metrics to Application Insights. The telegraf agent publishes [custom metrics](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/metrics-custom-overview) using the Azure Monitor REST API. Custom metrics are available in these [regions](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/metrics-custom-overview#supported-regions).
 
 This script is applicable if you are running Windows MPS Builds using Windows containers or processes for your game servers.
 
@@ -21,7 +21,7 @@ Instead, creating an Application Insights resource.
 ## Usage
 
 You should download telegraf from the [GitHub releases](https://github.com/influxdata/telegraf/releases) section. The [Windows amd64 package](https://dl.influxdata.com/telegraf/releases/telegraf-1.24.4_windows_amd64.zip) works with this sample.
-Then, you should create a [Application Insights](https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview) resource in your subscription.
+Then, you should create an [Application Insights](https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview) resource in your subscription.
 Copy the Instrumentation key from the Overview of the Application Insights resource you created and paste it into the telegraf.conf file.
 
 ```shell

--- a/windows_metrics_telegraf_azuremonitor/README.md
+++ b/windows_metrics_telegraf_azuremonitor/README.md
@@ -10,7 +10,7 @@ You can see documentation about Azure Monitor output telegraf plugin [here](http
 
 ## What it does
 
-This script uses [telegraf](https://www.influxdata.com/time-series-platform/telegraf/) agent to send VM metrics to Azure Monitor. The telegraf agent publishes [custom metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-custom-overview) using the Azure Monitor REST API. Custom metrics are available in these [regions](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-custom-overview#supported-regions).
+This script uses [telegraf](https://www.influxdata.com/time-series-platform/telegraf/) agent to send VM metrics to Azure Monitor. The telegraf agent publishes [custom metrics](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/metrics-custom-overview) using the Azure Monitor REST API. Custom metrics are available in these [regions](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/metrics-custom-overview#supported-regions).
 
 This script is applicable if you are running Windows MPS Builds using Windows containers or processes for your game servers.
 
@@ -21,7 +21,7 @@ Then, you should open a new [Azure Monitor](https://learn.microsoft.com/en-us/az
 
 You should create an Azure resource where the Azure Monitor metrics will be published to. For our sample, we created a VMSS (Virtual Machine Scaleset resource) with 0 Virtual Machines (so there is no compute charge) but a single VM in the deallocated state could also work. Once you do that, you should copy the resource ID and add it to the telegraf.conf file.
 
-We need telegraf to be able to authenticate to Azure Monitor on your subscription so it can post the metrics. Use the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/) to create a service principal with the "Monitoring Metrics Publisher" role for the subscription that metrics will be published against (subscription ID can be retrieved using `az account list` or from the Azure portal):
+We need telegraf to be able to authenticate to Azure Monitor on your subscription so it can post the metrics. Use the [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/) to create a service principal with the "Monitoring Metrics Publisher" role for the subscription that metrics will be published against (subscription ID can be retrieved using `az account list` or from the Azure portal):
 
 ```bash
 az ad sp create-for-rbac --role="Monitoring Metrics Publisher" --scopes="/subscriptions/<replace-with-subscription-id>"

--- a/windows_set_certificate_friendlyname/README.md
+++ b/windows_set_certificate_friendlyname/README.md
@@ -1,6 +1,6 @@
 # Windows - set certificate with friendly name
 
-The FriendlyName property is a Windows-only piece of metadata that can be included in a PFX certificate file. This field may get removed from any certificate uploaded as part of an PlayFab Build. In most cases this is acceptable--the FriendlyName is only supposed to help a human user identify a certificate when looking though a computer's certificate store.
+The FriendlyName property is a Windows-only piece of metadata that can be included in a PFX certificate file. This field may get removed from any certificate uploaded as part of a PlayFab Build. In most cases this is acceptable--the FriendlyName is only supposed to help a human user identify a certificate when looking though a computer's certificate store.
 Some programs, however, search for certificates using their FriendlyNames. If changing the program to search for the certificate using a more standard method (e.g. Subject, Thumbprint, etc) isn't possible, you can use this script to set the FriendlyName on startup.
 
 **NOTE**: This script is applicable only to Windows process-based Builds. In this case, certs are deployed to the local machine store of the VM so the VmStartupScript can access them and set the friendly name. If you are running Builds using Windows containers, you can use a similar script on your StartGameCommand (before you start your game server).


### PR DESCRIPTION
- Update docs.microsoft.com links to learn.microsoft.com across 6 READMEs
- Fix 'an PlayFab' -> 'a PlayFab' in windows_set_certificate_friendlyname
- Fix 'a Application Insights' -> 'an Application Insights'
- Fix 'a Azure Data Explorer' -> 'an Azure Data Explorer'
- Fix duplicate 'tenant tenant' in linux_logs_fluentbit_kusto and linux_logs_metrics_telegraf_kusto
- Improve awkward phrasing in linux_logs_fluentbit_kusto