### PR TITLE
Fix PSScriptAnalyzer action version and path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,9 +29,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run PSScriptAnalyzer
-        uses: microsoft/psscriptanalyzer-action@v2.0
+        uses: microsoft/psscriptanalyzer-action@main
         with:
-          path: '*.ps1'
+          path: './'
           recurse: true
           output: results.sarif
       - name: Upload SARIF results


### PR DESCRIPTION
- Change microsoft/psscriptanalyzer-action@v2.0 to @main (no version tags exist in that repo)
- Change path from '*.ps1' to './' (correct input format for the action)