### PR TITLE
Fix PSScriptAnalyzer CI job - use inline pwsh step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,13 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run PSScriptAnalyzer
-        uses: microsoft/psscriptanalyzer-action@main
-        with:
-          path: './'
-          recurse: true
-          output: results.sarif
-      - name: Upload SARIF results
-        if: always()
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: results.sarif
+        shell: pwsh
+        run: |
+          $results = Invoke-ScriptAnalyzer -Path ./ -Recurse -Severity Error
+          if ($results) {
+            $results | Format-Table -AutoSize
+            throw "PSScriptAnalyzer found $($results.Count) error(s)"
+          }
+          Write-Output "PSScriptAnalyzer: No errors found"


### PR DESCRIPTION
Replace third-party action + SARIF upload with inline pwsh step. The previous approach failed because:
- microsoft/psscriptanalyzer-action has no version tags
- codeql-action/upload-sarif needs security-events:write permission

The new approach runs Invoke-ScriptAnalyzer directly (pre-installed on GitHub runners), fails only on Error severity, and needs no special permissions.